### PR TITLE
[MNG-6829] Replace StringUtils#isEmpty(String) and #isNotEmpty(String)

### DIFF
--- a/src/main/java/org/apache/maven/doxia/linkcheck/DefaultLinkCheck.java
+++ b/src/main/java/org/apache/maven/doxia/linkcheck/DefaultLinkCheck.java
@@ -272,7 +272,7 @@ public final class DefaultLinkCheck
     @Override
     public void setEncoding( String encoding )
     {
-        if ( StringUtils.isEmpty( encoding ) )
+        if ( encoding == null || encoding.isEmpty() )
         {
             throw new IllegalArgumentException( "encoding is required" );
         }

--- a/src/main/java/org/apache/maven/doxia/linkcheck/validation/FileLinkValidator.java
+++ b/src/main/java/org/apache/maven/doxia/linkcheck/validation/FileLinkValidator.java
@@ -27,7 +27,6 @@ import java.util.Locale;
 import org.apache.maven.doxia.linkcheck.model.LinkcheckFileResult;
 import org.codehaus.plexus.util.IOUtil;
 import org.codehaus.plexus.util.ReaderFactory;
-import org.codehaus.plexus.util.StringUtils;
 import org.codehaus.plexus.util.WriterFactory;
 
 /**
@@ -46,7 +45,7 @@ public final class FileLinkValidator
      */
     public FileLinkValidator( String encoding )
     {
-        if ( StringUtils.isEmpty( encoding ) )
+        if ( encoding == null || encoding.isEmpty() )
         {
             encoding = WriterFactory.UTF_8;
         }

--- a/src/main/java/org/apache/maven/doxia/linkcheck/validation/LinkValidatorManager.java
+++ b/src/main/java/org/apache/maven/doxia/linkcheck/validation/LinkValidatorManager.java
@@ -322,9 +322,9 @@ public class LinkValidatorManager
      */
     protected static boolean matchPattern( String link, String pattern )
     {
-        if ( StringUtils.isEmpty( pattern ) )
+        if ( pattern == null || pattern.isEmpty() )
         {
-            return StringUtils.isEmpty( link );
+            return link == null || link.isEmpty();
         }
 
         if ( pattern.indexOf( '*' ) == -1 )


### PR DESCRIPTION
Continuation of https://issues.apache.org/jira/browse/MNG-6829

Review requested of @elharo

Use this link to re-run the recipe: https://public.moderne.io/recipes/org.openrewrite.java.migrate.apache.commons.lang.IsNotEmptyToJdk?organizationId=QXBhY2hlIE1hdmVu